### PR TITLE
Fixed case where a user is browsing old releases and …

### DIFF
--- a/Gov.News.WebApp/Controllers/Shared/IndexController.cs
+++ b/Gov.News.WebApp/Controllers/Shared/IndexController.cs
@@ -22,12 +22,12 @@ namespace Gov.News.Website.Controllers.Shared
         }
 
         [ResponseCache(CacheProfileName = "Feed"), Noindex]
-        public async Task<ActionResult> Feed(string key, string type, string format)
+        public async Task<ActionResult> Feed(string key, string postKind, string format)
         {
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
 
-            var model = await GetFeedModel(key, type);
+            var model = await GetFeedModel(key, postKind);
 
             if (model == null)
                 return NotFound();
@@ -42,7 +42,7 @@ namespace Gov.News.Website.Controllers.Shared
         }
 
         [ResponseCache(CacheProfileName = "Default"), Noindex, Obsolete]
-        public ActionResult MoreNews(string key, string type)
+        public ActionResult MoreNews(string key, string postKind)
         {
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
@@ -50,11 +50,11 @@ namespace Gov.News.Website.Controllers.Shared
             var ministry = this is MinistriesController ? key : null;
             var sector = this is CategoryController && !(this is MinistriesController) ? key : null;
             //var newstype = ConvertTypeToSingular(type);
-            return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = type });
+            return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = postKind });
         }
 
         [ResponseCache(CacheProfileName = "Archive"), Obsolete]
-        public ActionResult Archive(string key, string type)
+        public ActionResult Archive(string key, string postKind)
         {
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
@@ -62,11 +62,11 @@ namespace Gov.News.Website.Controllers.Shared
             var ministry = this is MinistriesController ? key : null;
             var sector = this is CategoryController && !(this is MinistriesController) ? key : null;
             ///var newstype = ConvertTypeToSingular(type);
-            return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = type });
+            return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = postKind });
         }
 
         [ResponseCache(CacheProfileName = "Archive"), Noindex, Obsolete]
-        public ActionResult Month(string key, string type, int year, int? month)
+        public ActionResult Month(string key, string postKind, int year, int? month)
         {
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
@@ -77,12 +77,12 @@ namespace Gov.News.Website.Controllers.Shared
             if (month.HasValue)
             {
                 var yearmonth = new DateTime(year, month.Value, 1).ToString("yyyy-MM-dd") + ".." + new DateTime(year, month.Value, 1).AddMonths(1).AddDays(-1).ToString("yyyy-MM-dd");
-                return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = type, daterange = yearmonth });
+                return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = postKind, daterange = yearmonth });
             }
             else
             {
                 var yearmonth = new DateTime(year, 1, 1).ToString("yyyy-MM-dd") + ".." + new DateTime(year, 1, 1).AddYears(1).AddDays(-1).ToString("yyyy-MM-dd");
-                return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = type, daterange = yearmonth });
+                return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = postKind, daterange = yearmonth });
             }
         }
 

--- a/Gov.News.WebApp/Repository.cs
+++ b/Gov.News.WebApp/Repository.cs
@@ -543,21 +543,16 @@ namespace Gov.News.Website
                 count += ProviderHelpers.MaximumLatestNewsItems;
             }
             DataIndex index = indexModel.Index;
+            int latestNewsCount = indexModel.LatestNews.Count();
             if (postKind == null)
             {
-                int latestNewsCount = indexModel.LatestNews.Count();
-
                 if (latestNewsCount > skip)
                 {
                     return indexModel.LatestNews.Skip(skip).Take(count);
                 }
-                if (skip != latestNewsCount)
-                {
-                    _logger.LogError("skip ({0})/count({1}) mismatch in GetLatestPostsAsync({2})!", skip, latestNewsCount, index.Key);
-                }
             }
             IList<Post> posts = await ApiClient.Posts.GetLatestAsync(index.Kind, index.Key, APIVersion, postKind, count, skip);
-            if (postKind != null) return posts;
+            if (postKind != null || skip != latestNewsCount) return posts;
 
             IDictionary<string, object> cacheForType = _cache[typeof(Post)];
             lock (cacheForType)


### PR DESCRIPTION
…a new release comes out that clears the cache.

Also fixed routes like  ministries/labour/stories/more-news