### PR TITLE
Move cacheClearHappenedWhileUserIsBrowsingOldReleases logic inside a …

### DIFF
--- a/Gov.News.WebApp/Controllers/Shared/IndexController.cs
+++ b/Gov.News.WebApp/Controllers/Shared/IndexController.cs
@@ -47,8 +47,9 @@ namespace Gov.News.Website.Controllers.Shared
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
 
-            var ministry = this is MinistriesController ? key : null;
-            var sector = this is CategoryController && !(this is MinistriesController) ? key : null;
+            var collection = (string)RouteData.Values["category"];
+            var ministry = collection == "ministries" ? key : null;
+            var sector = collection == "sectors" ? key : null;
             //var newstype = ConvertTypeToSingular(type);
             return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = postKind });
         }
@@ -59,8 +60,9 @@ namespace Gov.News.Website.Controllers.Shared
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
 
-            var ministry = this is MinistriesController ? key : null;
-            var sector = this is CategoryController && !(this is MinistriesController) ? key : null;
+            var collection = (string)RouteData.Values["category"];
+            var ministry = collection == "ministries" ? key : null;
+            var sector = collection == "sectors" ? key : null;
             ///var newstype = ConvertTypeToSingular(type);
             return RedirectToAction("Search", "Default", new { ministry = ministry, sector = sector, content = postKind });
         }
@@ -71,8 +73,9 @@ namespace Gov.News.Website.Controllers.Shared
             if (this.GetType().GetTypeInfo().IsDefined(typeof(ObsoleteAttribute), false))
                 return NotFound();
 
-            var ministry = this is MinistriesController ? key : null;
-            var sector = this is CategoryController && !(this is MinistriesController) ? key : null;
+            var collection = (string)RouteData.Values["category"];
+            var ministry = collection == "ministries" ? key : null;
+            var sector = collection == "sectors" ? key : null;
             //var newstype = ConvertTypeToSingular(type);
             if (month.HasValue)
             {
@@ -179,7 +182,7 @@ namespace Gov.News.Website.Controllers.Shared
             {
                 model.Title = "Home";
 
-                model.FeedUri = ProviderHelpers.Uri(new Uri (Configuration["NewsHostUri"]), "feed");
+                model.FeedUri = ProviderHelpers.Uri(new Uri(Configuration["NewsHostUri"]), "feed");
 
                 await homeModel.LoadTopAndFeaturePosts(Repository);
 

--- a/Gov.News.WebApp/Views/Default/SearchView.cshtml
+++ b/Gov.News.WebApp/Views/Default/SearchView.cshtml
@@ -89,7 +89,7 @@
                 <ul>
                     @if (!string.IsNullOrEmpty(Model.Query.NewsType))
                     {
-                        <li><b>Model.Query.NewsType.ToTitleCase()</b></li>
+                        <li><b>@Model.Query.NewsType.ToTitleCase()</b></li>
                     }
                     else
                     {


### PR DESCRIPTION
…lock block to avoid concurrency problems

Fix #2 for routes like  ministries/labour/stories/more-news