### PR TITLE
Remove some output caching since we have a good Repository cache

### DIFF
--- a/Gov.News.WebApp/Controllers/CategoryController.cs
+++ b/Gov.News.WebApp/Controllers/CategoryController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Gov.News.Api.Models;
-using Gov.News.Website.Middleware;
 using Gov.News.Website.Models;
 using Gov.News.Website.Providers;
 using Microsoft.AspNetCore.Mvc;
@@ -188,7 +187,6 @@ namespace Gov.News.Website.Controllers
             return model;
         }
 
-        [ResponseCache(CacheProfileName = "Default"), Noindex]
         public async Task<ActionResult> Index(string category)
         {
             var model = await GetViewModel(category);

--- a/Gov.News.WebApp/Controllers/Shared/NewsroomController.cs
+++ b/Gov.News.WebApp/Controllers/Shared/NewsroomController.cs
@@ -2,11 +2,12 @@
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Gov.News.Api.Models;
 using Gov.News.Website.Middleware;
 using Gov.News.Website.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 
 namespace Gov.News.Website.Controllers.Shared
 {
@@ -233,6 +234,19 @@ namespace Gov.News.Website.Controllers.Shared
             var client = new System.Net.Http.HttpClient();
 
             return await client.GetStreamAsync(new Uri(Repository.ContentDeliveryUri, blobName));
+        }
+
+        protected bool NotModifiedSince(DateTimeOffset? timestamp)
+        {
+            var modifiedSpan = timestamp - Request.GetTypedHeaders().IfModifiedSince;
+
+            // Ignore milliseconds because browsers are not supposed to store them
+            if (modifiedSpan.HasValue && modifiedSpan.Value.TotalMilliseconds < 1000)
+            {
+                return true;
+            }
+            Response.GetTypedHeaders().LastModified = timestamp;
+            return false;
         }
     }
 }

--- a/Gov.News.WebApp/RouteConfig.cs
+++ b/Gov.News.WebApp/RouteConfig.cs
@@ -94,7 +94,7 @@ namespace Gov.News.Website
 
             routes.MapRoute(
                 name: "Newsroom-SiteStatus",
-                template: "site/status",
+                template: "SiteStatus",
                 defaults: new { controller = "Default", action = "SiteStatus" }
             );
 
@@ -538,7 +538,7 @@ namespace Gov.News.Website
 
             routes.MapRoute(
                 name: "GetArticle",
-                template: "newsletters/{newletterKey}/{editionKey}/{articleKey}",
+                template: "newsletters/{newsletterKey}/{editionKey}/{articleKey}",
                 defaults: new { controller = "Newsletters", action = "GetArticle"}
             );
 


### PR DESCRIPTION
Added Status304NotModified where we can (not the PostsController because we would have to take into account the mega-menu(ministries), sidebar(media contacts, featured topics an services, related newsletters and posts), Live Webcast)

Also Changed /site/status to /SiteStatus to be consistent with Hub