### PR TITLE
Updating Default logging level to "information".

### DIFF
--- a/Gov.News.WebApp/appsettings.Development.json
+++ b/Gov.News.WebApp/appsettings.Development.json
@@ -4,7 +4,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "System": "Information",
       "Microsoft": "Information"
     }

--- a/Gov.News.WebApp/appsettings.Production.json
+++ b/Gov.News.WebApp/appsettings.Production.json
@@ -4,7 +4,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "System": "Information",
       "Microsoft": "Information"
     }

--- a/Gov.News.WebApp/appsettings.Staging.json
+++ b/Gov.News.WebApp/appsettings.Staging.json
@@ -2,7 +2,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "System": "Information",
       "Microsoft": "Information"
     }

--- a/Gov.News.WebApp/appsettings.Testing.json
+++ b/Gov.News.WebApp/appsettings.Testing.json
@@ -2,7 +2,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "System": "Information",
       "Microsoft": "Information"
     }

--- a/Gov.News.WebApp/appsettings.json
+++ b/Gov.News.WebApp/appsettings.json
@@ -20,7 +20,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "System": "Information",
       "Microsoft": "Information"
     }


### PR DESCRIPTION
At the request of the OpenShift staff updating default logging level to information.