### PR TITLE
Updated to stop exceptions from being thrown in production

### DIFF
--- a/Gov.News.WebApp/Controllers/Shared/IndexController.cs
+++ b/Gov.News.WebApp/Controllers/Shared/IndexController.cs
@@ -237,6 +237,9 @@ namespace Gov.News.Website.Controllers.Shared
         {
             DataIndex index = await GetDataIndex(key, (string)RouteData.Values["category"]);
 
+            if (index == null)
+                return null;
+
             var model = new SyndicationFeedViewModel();
             model.AlternateUri = new Uri(Configuration["NewsHostUri"]);
 

--- a/Gov.News.WebApp/RouteConfig.cs
+++ b/Gov.News.WebApp/RouteConfig.cs
@@ -18,7 +18,16 @@ namespace Gov.News.Website
 
             const string formats = "rss|atom";
             const string postKinds = "Stories|Releases|Factsheets|Updates";
-            const string categories = "Ministries|Sectors|Regions|Tags|Themes|Services";
+            
+            //Aug. 3/2018
+            //const string categories = "Ministries|Sectors|Regions|Tags|Themes|Services";
+            
+            //The line above has been updated. During the News work in Fall 2017 (BC Gov news public web api) and move to OpenShift
+            //Regions were not implemented in the application as they were never used. Therefore to prohibit the appliation throwing
+            //errors on routes containing regions, it is being removed fromt he routes.
+
+            //If regions are reimplmented in Repository.cs and the Web API, put them back in the route table.
+            const string categories = "Ministries|Sectors|Tags|Themes|Services";
 
             IRouteConstraint yearConstraint = new RegexRouteConstraint(@"^\d{4}$");
             IRouteConstraint monthConstraint = new RegexRouteConstraint(@"^(\d{2})?$");


### PR DESCRIPTION
The feeds controller had a flaw where it would throw exceptions when attempting to visit a feed, for an inactive ministry, sector, theme, tag, or service.  This corrects that.