### PR TITLE
Update social media links in GetConnectModel

### DIFF
--- a/Gov.News.WebApp/Controllers/DefaultController.cs
+++ b/Gov.News.WebApp/Controllers/DefaultController.cs
@@ -336,71 +336,69 @@ namespace Gov.News.Website.Controllers
 
             model.FacebookLinks = new Link[]
             {                 
-                        new Link() { Url = "http://www.facebook.com/BizPaLBC", Title = "BC BizPaL" },
+                        new Link() { Url = "https://www.facebook.com/BizPaLBC", Title = "BC BizPaL" },
                         new Link() { Url = "https://www.facebook.com/bchonours", Title = "BC Honours" },
                         new Link() { Url = "https://www.facebook.com/innovatebc", Title = "Innovate BC" },
-                        new Link() { Url = "http://www.facebook.com/YourBCParks", Title = "BC Parks" },
-                        new Link() { Url = "http://www.facebook.com/TranBC", Title = "BC Transportation and Infrastructure" },
-                        new Link() { Url = "http://www.facebook.com/BCForestFireInfo", Title = "BC Wildfire Service" },
+                        new Link() { Url = "https://www.facebook.com/YourBCParks", Title = "BC Parks" },
+                        new Link() { Url = "https://www.facebook.com/BCForestFireInfo", Title = "BC Wildfire Service" },
                         new Link() { Url = "https://www.facebook.com/ColumbiaRiverTreaty", Title = "Columbia River Treaty Review" },
                         new Link() { Url = "https://www.facebook.com/ConservationOfficerService", Title = "Conservation Officer Service" },
                         new Link() { Url = "https://www.facebook.com/QuitNowBC", Title = "QuitNowBC" },
-                        new Link() { Url = "http://www.facebook.com/BCRecSitesandTrails", Title = "Rec Sites and Trails BC" },
+                        new Link() { Url = "https://www.facebook.com/BCRecSitesandTrails", Title = "Rec Sites and Trails BC" },
                         new Link() { Url = "https://www.facebook.com/people/Residential-Tenancy-Branch-Province-of-BC/100088142227724/", Title = "Residential Tenancy Branch" },
                         new Link() { Url = "https://www.facebook.com/SuperNaturalBC ", Title = "Super, Natural British Columbia" },
-                        new Link() { Url = "http://www.facebook.com/WorkBC", Title = "WorkBC" },
+                        new Link() { Url = "https://www.facebook.com/WorkBC", Title = "WorkBC" },
                         new Link() { Url = "https://www.facebook.com/bchousing.org/", Title = "BC Housing" },
                         new Link() { Url = "https://www.facebook.com/PreparedBC/", Title = "PreparedBC" },
-                        new Link() { Url = "http://www.facebook.com/BCFireSafety", Title = "BC Fire Safety" },
+                        new Link() { Url = "https://www.facebook.com/BCFireSafety", Title = "BC Fire Safety" },
                         new Link() { Url = "https://www.facebook.com/AgriServiceBC", Title = "AgriService BC" },
                         new Link() { Url = "https://www.facebook.com/RoadSafetyBC", Title = "Road Safety BC" },
                         new Link() { Url = "https://www.facebook.com/HealthyBritishColumbia", Title = "HealthyBC" },
                         new Link() { Url = "https://www.facebook.com/EatDrinkBuyBC", Title = "Buy BC" },
                         new Link() { Url = "https://www.facebook.com/EmergencyInfoBC", Title = "Emergency Info BC" },
+                        new Link() { Url = "https://www.facebook.com/www.DriveBC.ca", Title = "DriveBC" },
             }.OrderBy(t => t.Title)
             .Prepend(new Link() { Url = "https://www.facebook.com/GovernmentOfBCChinese", Title = "Government of British Columbia Chinese (卑詩省政府中文官方帳號)", Summary = "" })
-            .Prepend(new Link() { Url = "http://www.facebook.com/BCProvincialGovernment", Title = "Government of British Columbia", Summary = "Join us for BC news, information and updates" })
+            .Prepend(new Link() { Url = "https://www.facebook.com/BCProvincialGovernment", Title = "Government of British Columbia", Summary = "Join us for BC news, information and updates" })
             .ToArray();
 
 
             model.YoutubeLinks = new Link[]
             {                        
-                         new Link() { Url = "http://www.youtube.com/bchousing1", Title = "BC Housing" },
+                         new Link() { Url = "https://www.youtube.com/bchousing1", Title = "BC Housing" },
                          new Link() { Url = "https://www.youtube.com/@BCDigitalTrust", Title = "BC Digital Trust" },
-                         new Link() { Url = "http://www.youtube.com/BCPublicService", Title = "BC Public Service" },
-                         new Link() { Url = "http://www.youtube.com/user/BCTradeInvest", Title = "BC Trade & Invest" },
+                         new Link() { Url = "https://www.youtube.com/BCPublicService", Title = "BC Public Service" },
+                         new Link() { Url = "https://www.youtube.com/user/BCTradeInvest", Title = "BC Trade & Invest" },
                          new Link() { Url = "https://www.youtube.com/@BCWildfireService", Title = "BC Wildfire Service" },
-                         new Link() { Url = "http://www.youtube.com/MinistryofTranBC", Title = "BC Ministry of Transportation and Transit" },
-                         new Link() { Url = "http://www.youtube.com/CareerTrekBC", Title = "Career Trek BC" },
-                         new Link() { Url = "http://www.youtube.com/EmergencyInfoBC", Title = "PreparedBC" },
+                         new Link() { Url = "https://www.youtube.com/MinistryofTranBC", Title = "BC Ministry of Transportation and Transit" },
+                         new Link() { Url = "https://www.youtube.com/CareerTrekBC", Title = "Career Trek BC" },
+                         new Link() { Url = "https://www.youtube.com/EmergencyInfoBC", Title = "PreparedBC" },
                          new Link() { Url = "https://www.youtube.com/user/QuitNowBC", Title = "QuitNowBC" },
-                         new Link() { Url = "http://www.youtube.com/user/TourismBC", Title = "Super, Natural British Columbia" },
-                         new Link() { Url = "http://www.youtube.com/workbc", Title = "WorkBC" },
+                         new Link() { Url = "https://www.youtube.com/user/TourismBC", Title = "Super, Natural British Columbia" },
+                         new Link() { Url = "https://www.youtube.com/workbc", Title = "WorkBC" },
                          new Link() { Url = "https://www.youtube.com/playlist?list=PL98F546CAAFA58723", Title = "BC Parks" },
-            }.OrderBy(t => t.Title).Prepend(new Link() { Url = "http://www.youtube.com/ProvinceofBC", Title = "Province of BC", Summary = "Subscribe to get the latest videos from the Government of British Columbia" }).ToArray();
+            }.OrderBy(t => t.Title).Prepend(new Link() { Url = "https://www.youtube.com/ProvinceofBC", Title = "Province of BC", Summary = "Subscribe to get the latest videos from the Government of British Columbia" }).ToArray();
 
             model.FlickrLinks = new Link[]
             {
-                         new Link() { Url = "http://www.flickr.com/photos/tranbc/", Title = "BC Ministry of Transportation & Transit's photostream" }
-            }.OrderBy(t => t.Title).Prepend(new Link() { Url = "http://www.flickr.com/photos/bcgovphotos", Title = "Province of BC", Summary = "View and share the latest photos from the Government of British Columbia" }).ToArray();
+                         new Link() { Url = "https://www.flickr.com/photos/tranbc/", Title = "BC Ministry of Transportation & Transit's photostream" }
+            }.OrderBy(t => t.Title).Prepend(new Link() { Url = "https://www.flickr.com/photos/bcgovphotos", Title = "Province of BC", Summary = "View and share the latest photos from the Government of British Columbia" }).ToArray();
 
             model.TwitterLinks = new Link[]
             {
                         new Link() { Url = "https://x.com/ComplianceBC", Title = "@ComplianceBC", Summary = "Environmental compliance in BC: changes, enforcement and education" },
-                        new Link() { Url = "http://x.com/bcgovfireinfo", Title = "@BCGovFireInfo", Summary = "Find updates on significant wildfires around the province" },
-                        new Link() { Url = "http://x.com/BC_Housing", Title = "@BC_Housing", Summary = "Learn about housing solutions and the latest projects in BC" },
+                        new Link() { Url = "https://x.com/bcgovfireinfo", Title = "@BCGovFireInfo", Summary = "Find updates on significant wildfires around the province" },
+                        new Link() { Url = "https://x.com/BC_Housing", Title = "@BC_Housing", Summary = "Learn about housing solutions and the latest projects in BC" },
                         new Link() { Url = "https://x.com/innovate_bc", Title = "@Innovate_BC", Summary = "Info on developing entrepreneurial talent and commercializing technology in BC" },
                         new Link() { Url = "https://x.com/BCTradeInvest", Title = "@BCTradeInvest", Summary = "Find expertise to help your business grow internationally" },
-                        new Link() { Url = "http://x.com/CRTreaty", Title = "@CRTreaty", Summary = "Join the discussion on the Columbia River Treaty Review" },
-                        new Link() { Url = "http://x.com/DriveBC", Title = "@DriveBC" , Summary = "Get developing road closure & weather information in BC" },
-                        new Link() { Url = "http://x.com/emergencyinfobc", Title = "@EmergencyInfoBC" , Summary = "Receive current and verified updates, safety instructions, and links to official sources during emergencies in B.C." },
+                        new Link() { Url = "https://x.com/CRTreaty", Title = "@CRTreaty", Summary = "Join the discussion on the Columbia River Treaty Review" },
+                        new Link() { Url = "https://x.com/DriveBC", Title = "@DriveBC" , Summary = "Get developing road closure & weather information in BC" },
+                        new Link() { Url = "https://x.com/emergencyinfobc", Title = "@EmergencyInfoBC" , Summary = "Receive current and verified updates, safety instructions, and links to official sources during emergencies in B.C." },
                         new Link() { Url = "https://x.com/PreparedBC", Title = "@PreparedBC" , Summary = "Ready for a disaster? Get preparedness tips & recovery info here." },
-                        new Link() { Url = "http://x.com/govTogetherBC", Title = "@govTogetherBC" , Summary = "Find consultation and engagement opportunities in BC" },
-                        new Link() { Url = "http://x.com/quitnowbc", Title = "@QuitNowBC", Summary = "Want to quit smoking? We can help!" },
-                        new Link() { Url = "http://x.com/RoadSafetyBC", Title = "@RoadSafetyBC" , Summary = "Get information on road safety and driver behaviour" },
-                        new Link() { Url = "http://x.com/TranBC", Title = "@TranBC" , Summary = "Engaging on BC transportation and transit services, projects and safety" },
-                        new Link() { Url = "https://x.com/TranBC_LMD", Title = "@TranBC_LMD" , Summary = "Latest info from the Lower Mainland" },
-                        new Link() { Url = "http://x.com/WorkBC", Title = "@WorkBC", Summary = "Explore career paths and get tips for finding jobs in British Columbia" },
+                        new Link() { Url = "https://x.com/govTogetherBC", Title = "@govTogetherBC" , Summary = "Find consultation and engagement opportunities in BC" },
+                        new Link() { Url = "https://x.com/quitnowbc", Title = "@QuitNowBC", Summary = "Want to quit smoking? We can help!" },
+                        new Link() { Url = "https://x.com/RoadSafetyBC", Title = "@RoadSafetyBC" , Summary = "Get information on road safety and driver behaviour" },
+                        new Link() { Url = "https://x.com/WorkBC", Title = "@WorkBC", Summary = "Explore career paths and get tips for finding jobs in British Columbia" },
                         new Link() { Url = "https://x.com/BCSheriffs", Title = "@BCSheriffs", Summary = "Learn about the diverse responsibilities and activities of the BC Sheriff Service" },
                         new Link() { Url = "https://x.com/creativebcs", Title = "@CreativeBCs", Summary = "Find information on BC's film, TV, music, interactive & digital media, books & magazines" },
                         new Link() { Url = "https://x.com/bc_eao", Title = "@BC_EAO", Summary = "Get project updates and environmental assessment information" },
@@ -417,7 +415,6 @@ namespace Gov.News.Website.Controllers
                         new Link() { Url = "https://www.instagram.com/bchonours", Title = "BC Honours", Summary = "" },
                         new Link() { Url = "https://www.instagram.com/bchousing/", Title = "BC Housing", Summary = "" },
                         new Link() { Url = "https://www.instagram.com/yourbcparks/", Title = "BC Parks", Summary = "" },
-                        new Link() { Url = "https://www.instagram.com/ministryoftranbc/", Title = "BC Ministry of Transportation and Transit", Summary = "" },
                         new Link() { Url = "https://www.instagram.com/creativebcs/", Title = "Creative BC", Summary = "" },
                         new Link() { Url = "https://www.instagram.com/supernaturalbc/", Title = "Super, Natural British Columbia", Summary = "" },
                         new Link() { Url = "https://www.instagram.com/innovate_bc/", Title = "Innovate BC", Summary = "" },
@@ -433,7 +430,7 @@ namespace Gov.News.Website.Controllers
             model.BlueskyLinks = new Link[]
             {
                 new Link() { Url = "https://bsky.app/profile/tradeandinvestbc.bsky.social", Title = "Trade and Invest British Columbia", Summary = "" },
-            }.OrderBy(t => t.Title).Prepend(new Link() { Url = "http://governmentofbc.bsky.social", Title = "Government of BC", Summary = "Read news from the Government of British Columbia" }).ToArray();
+            }.OrderBy(t => t.Title).Prepend(new Link() { Url = "https://governmentofbc.bsky.social", Title = "Government of BC", Summary = "Read news from the Government of British Columbia" }).ToArray();
 
             model.ThreadsLinks = new Link[]
            {
@@ -443,7 +440,6 @@ namespace Gov.News.Website.Controllers
             model.BlogsLinks = new Link[]
             {
                         new Link() { Url = "https://www.britishcolumbia.ca/about-trade-and-invest-bc/news-stories/", Title = "BC Trade and Invest" },
-                        new Link() { Url = "http://www.tranbc.ca/", Title = "TranBC" },
                         new Link() { Url = "https://www.workbc.ca/plan-career/quick-reads", Title = "WorkBC" },
                         new Link() { Url = "https://engage.gov.bc.ca/bcparksblog", Title = "BC Parks" },
             }.OrderBy(t => t.Title).Prepend(new Link() { Url = "https://engage.gov.bc.ca/govtogetherbc/", Title = "GovTogetherBC" }).ToArray();


### PR DESCRIPTION
Closes #1177

Updates the hardcoded social media link arrays in `DefaultController.GetConnectModel()` per the CSV attached to the issue's `Notes` column instructions:

- **Facebook**: http→https for Government of BC, BC BizPaL, BC Fire Safety, BC Parks, BC Wildfire Service, Rec Sites and Trails BC, WorkBC; removed "BC Transportation and Infrastructure"; added "DriveBC"
- **X (Twitter)**: http→https for @BC_Housing, @BCGovFireInfo, @CRTreaty, @DriveBC, @EmergencyInfoBC, @govTogetherBC, @QuitNowBC, @RoadSafetyBC, @WorkBC; removed @TranBC and @TranBC_LMD
- **Instagram**: removed "BC Ministry of Transportation and Transit"
- **Bluesky**: http→https for Government of BC
- **Flickr**: http→https for Province of BC and BC Ministry of Transportation & Transit's photostream
- **YouTube**: http→https for Province of BC, BC Housing, BC Ministry of Transportation and Transit, BC Public Service, BC Trade & Invest, Career Trek BC, PreparedBC, Super Natural British Columbia, WorkBC
- **Blogs**: removed "TranBC" (WorkBC blog link was already https, no change needed)
- LinkedIn/Threads had no notes in the CSV — left unchanged

Only `Gov.News.WebApp/Controllers/DefaultController.cs` was modified.

## Verification
`dotnet build` fails on this environment with a pre-existing `rzc generate` error unrelated to this change — confirmed identical failure on the unmodified `develop` branch via `git stash`. No other automated tests target this method.