### PR TITLE
Update WorkBC blog link in GetConnectModel

### DIFF
--- a/Gov.News.WebApp/Controllers/DefaultController.cs
+++ b/Gov.News.WebApp/Controllers/DefaultController.cs
@@ -440,7 +440,7 @@ namespace Gov.News.Website.Controllers
             model.BlogsLinks = new Link[]
             {
                         new Link() { Url = "https://www.britishcolumbia.ca/about-trade-and-invest-bc/news-stories/", Title = "BC Trade and Invest" },
-                        new Link() { Url = "https://www.workbc.ca/plan-career/quick-reads", Title = "WorkBC" },
+                        new Link() { Url = "https://www.workbc.ca/quick-reads", Title = "WorkBC" },
                         new Link() { Url = "https://engage.gov.bc.ca/bcparksblog", Title = "BC Parks" },
             }.OrderBy(t => t.Title).Prepend(new Link() { Url = "https://engage.gov.bc.ca/govtogetherbc/", Title = "GovTogetherBC" }).ToArray();
 


### PR DESCRIPTION
Fixes #1179

Updates the WorkBC link under `model.BlogsLinks` in `GetConnectModel()` from `https://www.workbc.ca/plan-career/quick-reads` to `https://www.workbc.ca/quick-reads`, as requested in the issue.